### PR TITLE
feat(create-element): init 参数使用 projectName \ 统一生成目录的前缀

### DIFF
--- a/packages/create-element/.gitignore
+++ b/packages/create-element/.gitignore
@@ -5,6 +5,7 @@
 .eslintcache
 
 package-lock.json
+yarn.lock
 
 npm-debug.log
 yarn-error.log

--- a/packages/create-element/src/base.ts
+++ b/packages/create-element/src/base.ts
@@ -17,11 +17,11 @@ export default class InitFunc {
   answers: IAnswer;
   prefix: string;
   constructor({ argv, answers, templatePkg, prefix }) {
-    this.projectName = argv['_'][0] || './';
+    this.projectName = argv['_'][0] || answers.projectName;
     this.installPath = getInstallPath();
     this.templatePkg = templatePkg;
-    this.copyPath = path.join(process.cwd(), this.projectName);
     this.answers = answers;
+    this.copyPath = path.join(process.cwd(), `${this.answers.componentType}-${this.projectName}`);
     this.prefix = prefix;
   }
   addPrefix(name) {


### PR DESCRIPTION
改动点1：
```bash
 npm init @alilc/element your-element-name
```

your-element-name 改成非必传

改动点2：

参考 https://github.com/alibaba/lowcode-plugins/tree/main/packages 的  plugin 命名方式，给生成的文件夹拼接 plugin-、setter-、component- 前缀

目前生成的 plugin 跟  setter 文件模板，会自动拼接成 LowcodePluginXXX 跟 LowcodeSetterXXX，所以文件夹名称统一更好？

![image](https://user-images.githubusercontent.com/17792166/162154042-cd158d13-c6af-4873-b57a-fa189da00b67.png)



