### PR TITLE
feat(create-element): 避免 prefix 出现重复

### DIFF
--- a/packages/create-element/src/base.ts
+++ b/packages/create-element/src/base.ts
@@ -24,8 +24,11 @@ export default class InitFunc {
     this.answers = answers;
     this.prefix = prefix;
   }
-  addPrefix(name) {
+  addPrefix(name: string) {
     const prefix = this.prefix;
+    if (name.startsWith(this.answers.componentType)) {
+      name = name.slice(this.answers.componentType.length)
+    }
     if (new RegExp(`^${prefix}`).test(name)) {
       return name;
     }


### PR DESCRIPTION
如使用```npm init @alilc/element plugin-aaa```或```npm init @alilc/element setter-aaa```初始化

会出现导出的 plugin name 或 setter name 出现重复

<img width="963" alt="image" src="https://user-images.githubusercontent.com/17792166/162348541-80f30a25-1ea5-49e9-8f20-5a35d225015b.png">

