### PR TITLE
fix: Close https://github.com/alibaba/lowcode-engine/issues/826

### DIFF
--- a/packages/build-plugin-lowcode/demo/antd-setter-map/build.lowcode.js
+++ b/packages/build-plugin-lowcode/demo/antd-setter-map/build.lowcode.js
@@ -1,0 +1,23 @@
+const package = require('./package.json');
+
+module.exports = {
+  alias: {
+    '@': './src/components',
+  },
+  plugins: [
+    [
+      '../../src/index.js',
+      {
+        engineScope: '@alilc',
+        setterMap: {
+          InputSetter: '../src/setters/InputSetter',
+        },
+        npmClient: 'cnpm',
+        staticResources: {
+          antdJsUrl: 'https://g.alicdn.com/code/lib/antd/4.20.0/antd.min.js',
+          antdCssUrl: 'https://g.alicdn.com/code/lib/antd/4.20.0/antd.min.css'
+        }
+      },
+    ],
+  ],
+};

--- a/packages/build-plugin-lowcode/demo/antd-setter-map/lowcode/button/meta.ts
+++ b/packages/build-plugin-lowcode/demo/antd-setter-map/lowcode/button/meta.ts
@@ -1,0 +1,50 @@
+
+import { ComponentMetadata, Snippet } from '@alilc/lowcode-types';
+
+const ButtonMeta: ComponentMetadata = {
+  "componentName": "Button",
+  "title": "Button",
+  "docUrl": "",
+  "screenshot": "",
+  "devMode": "proCode",
+  group: '测试组件',
+  "npm": {
+    "package": "@alilc/example-components",
+    "version": "1.0.0",
+    "exportName": "Button",
+    "main": "src/index.tsx",
+    "destructuring": true,
+    "subName": ""
+  },
+  "configure": {
+    "props": [
+      {
+        name: 'title',
+        title: {
+          label: 'title',
+          tip: "标题",
+        },
+        setter: ['StringSetter', 'VariableSetter', 'InputSetter'],
+      },
+    ],
+    "supports": {
+      "style": true
+    },
+    "component": {}
+  }
+};
+const snippets: Snippet[] = [
+  {
+    "title": "Button",
+    "screenshot": "",
+    "schema": {
+      "componentName": "Button",
+      "props": {}
+    }
+  }
+];
+
+export default {
+  ...ButtonMeta,
+  snippets
+};

--- a/packages/build-plugin-lowcode/demo/antd-setter-map/package.json
+++ b/packages/build-plugin-lowcode/demo/antd-setter-map/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@alilc/example-components",
+  "version": "1.0.0",
+  "description": "A component library based on Fusion Next",
+  "files": [
+    "docs/",
+    "es/",
+    "lib/",
+    "build/"
+  ],
+  "main": "lib/index.js",
+  "module": "es/index.js",
+  "stylePath": "style.js",
+  "scripts": {
+    "start": "build-scripts start --config ./build.lowcode.js",
+    "build": "build-scripts build --config ./build.lowcode.js",
+    "lint": "f2elint scan",
+    "lint:fix": "f2elint fix"
+  },
+  "keywords": [
+    "ice",
+    "react",
+    "component"
+  ],
+  "dependencies": {
+    "@storybook/addon-docs": "^6.3.4",
+    "@storybook/addon-essentials": "^6.3.4",
+    "@storybook/addon-storysource": "^6.3.4",
+    "moment": "^2.29.1",
+    "prop-types": "^15.5.8"
+  },
+  "devDependencies": {
+    "@alib/build-scripts": "^0.1.3",
+    "@alifd/next": "^1.x"
+  },
+  "peerDependencies": {
+    "@alifd/next": "1.x",
+    "react": "^16.9.0",
+    "react-dom": "^16.9.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "husky": {
+    "hooks": {
+      "pre-commit": "f2elint commit-file-scan",
+      "commit-msg": "f2elint commit-msg-scan"
+    }
+  },
+  "componentConfig": {
+    "materialSchema": "https://unpkg.com/@alilc/example-components@1.0.0/build/lowcode/assets-prod.json"
+  }
+}

--- a/packages/build-plugin-lowcode/demo/antd-setter-map/src/components/button/index.tsx
+++ b/packages/build-plugin-lowcode/demo/antd-setter-map/src/components/button/index.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { Button } from '@alifd/next';
+
+interface ComponentProps {
+  title: string;
+}
+
+export default function ComponentB(props: ComponentProps) {
+  const { title, children = '按钮', ...others } = props;
+
+  return (
+    <div className="ExampleComponent" {...others}>
+      {title}
+      <Button>{children}</Button>
+    </div>
+  );
+}

--- a/packages/build-plugin-lowcode/demo/antd-setter-map/src/index.scss
+++ b/packages/build-plugin-lowcode/demo/antd-setter-map/src/index.scss
@@ -1,0 +1,1 @@
+$biz-css-prefix: '.bizpack';

--- a/packages/build-plugin-lowcode/demo/antd-setter-map/src/index.tsx
+++ b/packages/build-plugin-lowcode/demo/antd-setter-map/src/index.tsx
@@ -1,0 +1,5 @@
+
+import Button from './components/button';
+
+export const bizCssPrefix = 'bizpack';
+export { Button };

--- a/packages/build-plugin-lowcode/demo/antd-setter-map/src/setters/InputSetter.tsx
+++ b/packages/build-plugin-lowcode/demo/antd-setter-map/src/setters/InputSetter.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { Input } from 'antd'
+import { createElement } from 'react';
+
+export interface IAntdSetterProps {
+  value?: string;
+  defaultValue?: string;
+  placeholder?: string;
+  onChange?: (val: string) => void;
+}
+
+const InputSetter: React.FC<IAntdSetterProps> = ({
+  onChange,
+  placeholder = '请输入',
+  value,
+}) => {
+  return (
+    <div>
+      <Input
+        type="text"
+        value={value}
+        placeholder={placeholder}
+        onChange={(e) => {
+          const val = e.currentTarget.value;
+          onChange?.(val);
+        }}
+        style={{ width: '100%' }}
+      />
+    </div>
+  );
+};
+
+export default InputSetter;

--- a/packages/build-plugin-lowcode/demo/antd-setter-map/tsconfig.json
+++ b/packages/build-plugin-lowcode/demo/antd-setter-map/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "compilerOptions": {
+    "outDir": "build",
+    "module": "esnext",
+    "target": "es6",
+    "jsx": "react",
+    "moduleResolution": "node",
+    "lib": ["es6", "dom"],
+    "sourceMap": true,
+    "allowJs": true,
+    "noUnusedLocals": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/*.ts", "src/*.tsx"],
+  "exclude": ["node_modules", "build", "public"]
+}

--- a/packages/build-plugin-lowcode/package.json
+++ b/packages/build-plugin-lowcode/package.json
@@ -8,7 +8,8 @@
   ],
   "scripts": {
     "component:dev": "cd demo/component && npm start",
-    "setter:dev": "cd demo/setter && npm start"
+    "setter:dev": "cd demo/setter && npm start",
+    "antdSetterMap:dev": "cd demo/antd-setter-map && npm start"
   },
   "repository": {
     "type": "git",

--- a/packages/build-plugin-lowcode/src/public/index.html
+++ b/packages/build-plugin-lowcode/src/public/index.html
@@ -47,6 +47,9 @@
     <link rel="stylesheet" href="<%= enginePresetCssUrl %>" />
     <link href="<%= themeVariableUrl %>" rel="stylesheet" />
     <link href="<%= themeStyleUrl %>" rel="stylesheet" />
+    <% if (typeof antdCssUrl === 'string') { %>
+      <link href="<%= antdCssUrl %>" rel="stylesheet" />
+    <% } %>
     <div id="lce-container"></div>
     <script src="https://g.alicdn.com/code/lib/rax/1.1.0/rax.umd.min.js"></script>
     <script src="https://g.alicdn.com/code/lib/react/16.9.0/umd/react.development.js"></script>
@@ -58,6 +61,9 @@
     <script src="https://g.alicdn.com/platform/c/??react15-polyfill/0.0.1/dist/index.js,lodash/4.6.1/lodash.min.js,immutable/3.7.6/dist/immutable.min.js,natty-storage/2.0.2/dist/natty-storage.min.js,natty-fetch/2.6.0/dist/natty-fetch.pc.min.js,tinymce/4.2.5/tinymce-full.js"></script>
     <script src="https://g.alicdn.com/mylib/moment/2.24.0/min/moment.min.js"></script>
     <script src="https://g.alicdn.com/code/lib/alifd__next/1.23.20/next-with-locales.min.js"></script>
+    <% if (typeof antdJsUrl === 'string') { %>
+      <script crossorigin="anonymous" src="<%= antdJsUrl %>"></script>
+    <% } %>
     <script crossorigin="anonymous" src="<%= engineCoreJsUrl %>"></script>
     <script crossorigin="anonymous" src="<%= engineExtJsUrl %>"></script>
     <script>


### PR DESCRIPTION
支持 antd 的 setterMap，详见 https://github.com/alibaba/lowcode-engine/issues/826

用法：
```javascript
const package = require('./package.json');

module.exports = {
  alias: {
    '@': './src/components',
  },
  plugins: [
    [
      '../../src/index.js',
      {
        engineScope: '@alilc',
        setterMap: {
          AntdSetter: '../src/setters/AntdSetter',
        },
        npmClient: 'cnpm',
        staticResources: {
          antdJsUrl: 'https://g.alicdn.com/code/lib/antd/4.20.0/antd.min.js',
          antdCssUrl: 'https://g.alicdn.com/code/lib/antd/4.20.0/antd.min.css'
        }
      },
    ],
  ],
};
```

staticResources 字段支持传入 antd 资源

启动测试用例:
```bash
# 1 
cd packages && cd build-plugin-lowcode
# 2
npm run setterMap:dev
```

效果可见：

<img width="1774" alt="image" src="https://user-images.githubusercontent.com/17792166/182153223-8234ccd7-c8a1-4534-ac50-2e7e494ff9eb.png">
