### PR TITLE
feat: support config inject server host

### DIFF
--- a/packages/build-plugin-alt/src/index.ts
+++ b/packages/build-plugin-alt/src/index.ts
@@ -87,9 +87,10 @@ const plugin: IPlugin = ({ context, registerTask, onGetWebpackConfig, onHook, lo
         openBrowser(openUrl || url);
       }
     })
-    onHook('before.start.load', ({ args }) => {
+    onHook('before.start.devServer', (server) => {
+      const injectServerHost = server['urls'].lanUrlForConfig;
       if (inject) {
-        makeInjectInfo({ pkg, port: args.port, type, library });
+        makeInjectInfo({ pkg, port: server.devServer.options.port, type, library, altServerHost: injectServerHost });
         injectApis();
       }
     });
@@ -100,8 +101,8 @@ const plugin: IPlugin = ({ context, registerTask, onGetWebpackConfig, onHook, lo
       const babelPlugins = [];
       if (type === 'plugin' && generateMeta && pkg.lcMeta) {
         babelPlugins.push([require.resolve('./babelPluginMeta'), {
-          filename: mainFile,
-          meta: pkg.lcMeta,
+            filename: mainFile,
+            meta: pkg.lcMeta,
         }])
       }
       babelCompiler(context, {

--- a/packages/build-plugin-alt/src/inject/config.ts
+++ b/packages/build-plugin-alt/src/inject/config.ts
@@ -7,21 +7,21 @@ interface IOptions extends Partial<PluginContext> {
 }
 
 export default (config: WebpackChain, { pkg, type }: IOptions) => {
- config.entryPoints.clear();
- config.merge({
-   entry: {
-     utils: path.join(__dirname, 'entry.js'),
-   },
- });
- config.output.library('__injectComponent');
- config.output.libraryTarget('jsonp');
- config.devServer.host('127.0.0.1');
- config.plugin('define').tap((args) => {
+  config.entryPoints.clear();
+  config.merge({
+    entry: {
+      utils: path.join(__dirname, 'entry.js'),
+    },
+  });
+  config.output.library('__injectComponent');
+  config.output.libraryTarget('jsonp');
+  config.devServer.host('0.0.0.0');
+  config.plugin('define').tap((args) => {
    return [{
-     ...args[0],
-     __altUtilsName: JSON.stringify(`__lowcode-${type}-demo__`),
-     __bundleType: JSON.stringify(type === 'plugin' ? 'designerPlugin' : 'setter'),
-     name: JSON.stringify(pkg.name),
+        ...args[0],
+        __altUtilsName: JSON.stringify(`__lowcode-${type}-demo__`),
+        __bundleType: JSON.stringify(type === 'plugin' ? 'designerPlugin' : 'setter'),
+        name: JSON.stringify(pkg.name),
    }]
- });
+  });
 }

--- a/packages/build-plugin-alt/src/inject/makeInjectInfo.ts
+++ b/packages/build-plugin-alt/src/inject/makeInjectInfo.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import { getFilePath } from './utils';
 
-export default ({ pkg, port, type, library }) => {
+export default ({ pkg, port, type, library, injectServerHost }) => {
   const cacheFilePath = getFilePath();
   fs.ensureFileSync(cacheFilePath);
   let cache = {};
@@ -14,20 +14,20 @@ export default ({ pkg, port, type, library }) => {
       type: type === 'plugin' ? 'designerPlugin' : 'setter',
       library,
       subType: '',
-      url: `http://127.0.0.1:${port}/js/utils.js?name=${pkg.name}`,
+      url: `http://${injectServerHost}:${port}/js/utils.js?name=${pkg.name}`,
     };
   } else {
     cache[`${port}-view`] = {
       packageName: pkg.name,
       library,
       type: 'view',
-      url: `http://127.0.0.1:${port}/view.js?name=${pkg.name}`,
+      url: `http://${injectServerHost}:${port}/view.js?name=${pkg.name}`,
     };
     cache[`${port}-meta`] = {
       packageName: pkg.name,
       library,
       type: 'meta',
-      url: `http://127.0.0.1:${port}/meta.js?name=${pkg.name}`,
+      url: `http://${injectServerHost}:${port}/meta.js?name=${pkg.name}`,
     }
   }
 


### PR DESCRIPTION
背景：在本机开发好物料，注入到demo项目没有问题，同局域网下的其他主机访问则不能注入物料，因此修改部分逻辑支持该场景，修改逻辑如下，lowcode-plugin-inject 支持通过请求参数控制获取注入资源的主机地址，注入服务监听端口修改为0.0.0.0，返回的注入资源路径以devServer 当前运行的主机Ip为准