### PR TITLE
feat:support config inject server host

### DIFF
--- a/packages/build-plugin-alt/src/index.ts
+++ b/packages/build-plugin-alt/src/index.ts
@@ -77,14 +77,6 @@ const plugin: IPlugin = ({ context, registerTask, onGetWebpackConfig, onHook, lo
       // })
     }
 
-    onHook('before.start.devServer', (server) => {
-      const injectServerHost = server['urls'].lanUrlForConfig;
-      if (inject) {
-        makeInjectInfo({ pkg, port: server.devServer.options.port, type, library, injectServerHost });
-        injectApis();
-      }
-    });
-
     onHook('after.start.devServer', ({ url }) => {
       if (inject) {
         if (openUrl) {
@@ -96,6 +88,13 @@ const plugin: IPlugin = ({ context, registerTask, onGetWebpackConfig, onHook, lo
         openBrowser(openUrl || url);
       }
     })
+
+    onHook('before.start.load', ({ args }) => {
+      if (inject) {
+        makeInjectInfo({ pkg, host: args.host || '127.0.0.1', port: args.port, type, library });
+        injectApis();
+      }
+    });
 
   } else if (command === 'build' && type !== 'component') {
     const { basicComponents = [] } = userConfig;

--- a/packages/build-plugin-alt/src/index.ts
+++ b/packages/build-plugin-alt/src/index.ts
@@ -70,12 +70,21 @@ const plugin: IPlugin = ({ context, registerTask, onGetWebpackConfig, onHook, lo
           builtinConfig(config);
         });
       }
-      
+
     } else {
       // onGetWebpackConfig('lowcode-dev', (config) => {
       //   console.log(config.toConfig());
       // })
     }
+
+    onHook('before.start.devServer', (server) => {
+      const injectServerHost = server['urls'].lanUrlForConfig;
+      if (inject) {
+        makeInjectInfo({ pkg, port: server.devServer.options.port, type, library, injectServerHost });
+        injectApis();
+      }
+    });
+
     onHook('after.start.devServer', ({ url }) => {
       if (inject) {
         if (openUrl) {
@@ -87,12 +96,6 @@ const plugin: IPlugin = ({ context, registerTask, onGetWebpackConfig, onHook, lo
         openBrowser(openUrl || url);
       }
     })
-    onHook('before.start.load', ({ args }) => {
-      if (inject) {
-        makeInjectInfo({ pkg, port: args.port, type, library });
-        injectApis();
-      }
-    });
 
   } else if (command === 'build' && type !== 'component') {
     const { basicComponents = [] } = userConfig;

--- a/packages/build-plugin-alt/src/inject/config.ts
+++ b/packages/build-plugin-alt/src/inject/config.ts
@@ -15,7 +15,7 @@ export default (config: WebpackChain, { pkg, type }: IOptions) => {
  });
  config.output.library('__injectComponent');
  config.output.libraryTarget('jsonp');
- config.devServer.host('127.0.0.1');
+ config.devServer.host('0.0.0.0');
  config.plugin('define').tap((args) => {
    return [{
      ...args[0],

--- a/packages/build-plugin-alt/src/inject/makeInjectInfo.ts
+++ b/packages/build-plugin-alt/src/inject/makeInjectInfo.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import { getFilePath } from './utils';
 
-export default ({ pkg, port, type, library }) => {
+export default ({ pkg, port, type, library, injectServerHost }) => {
   const cacheFilePath = getFilePath();
   fs.ensureFileSync(cacheFilePath);
   let cache = {};
@@ -14,20 +14,20 @@ export default ({ pkg, port, type, library }) => {
       type: type === 'plugin' ? 'designerPlugin' : 'setter',
       library,
       subType: '',
-      url: `http://127.0.0.1:${port}/js/utils.js?name=${pkg.name}`,
+      url: `http://${injectServerHost}:${port}/js/utils.js?name=${pkg.name}`,
     };
   } else {
     cache[`${port}-view`] = {
       packageName: pkg.name,
       library,
       type: 'view',
-      url: `http://127.0.0.1:${port}/view.js?name=${pkg.name}`,
+      url: `http://${injectServerHost}:${port}/view.js?name=${pkg.name}`,
     };
     cache[`${port}-meta`] = {
       packageName: pkg.name,
       library,
       type: 'meta',
-      url: `http://127.0.0.1:${port}/meta.js?name=${pkg.name}`,
+      url: `http://${injectServerHost}:${port}/meta.js?name=${pkg.name}`,
     }
   }
 

--- a/packages/build-plugin-alt/src/inject/makeInjectInfo.ts
+++ b/packages/build-plugin-alt/src/inject/makeInjectInfo.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import { getFilePath } from './utils';
 
-export default ({ pkg, port, type, library, injectServerHost }) => {
+export default ({ pkg, host, port, type, library}) => {
   const cacheFilePath = getFilePath();
   fs.ensureFileSync(cacheFilePath);
   let cache = {};
@@ -14,20 +14,20 @@ export default ({ pkg, port, type, library, injectServerHost }) => {
       type: type === 'plugin' ? 'designerPlugin' : 'setter',
       library,
       subType: '',
-      url: `http://${injectServerHost}:${port}/js/utils.js?name=${pkg.name}`,
+      url: `http://${host}:${port}/js/utils.js?name=${pkg.name}`,
     };
   } else {
     cache[`${port}-view`] = {
       packageName: pkg.name,
       library,
       type: 'view',
-      url: `http://${injectServerHost}:${port}/view.js?name=${pkg.name}`,
+      url: `http://${host}:${port}/view.js?name=${pkg.name}`,
     };
     cache[`${port}-meta`] = {
       packageName: pkg.name,
       library,
       type: 'meta',
-      url: `http://${injectServerHost}:${port}/meta.js?name=${pkg.name}`,
+      url: `http://${host}:${port}/meta.js?name=${pkg.name}`,
     }
   }
 

--- a/packages/lowcode-plugin-inject/src/index.tsx
+++ b/packages/lowcode-plugin-inject/src/index.tsx
@@ -6,6 +6,7 @@ import { Notification } from '@alifd/next';
 
 let injectedPluginConfigMap = null;
 let injectedPlugins = [];
+let injectServerHost = '127.0.0.1';
 
 export async function getInjectedPlugin(name: string, ctx: ILowCodePluginContext) {
   if (!injectedPluginConfigMap) {
@@ -21,7 +22,19 @@ export async function getInjectedPlugin(name: string, ctx: ILowCodePluginContext
   return injectedPluginConfigMap[name];
 }
 
-const Inject = (ctx: ILowCodePluginContext) => {
+export function getInjectServerHost() {
+  return injectServerHost;
+}
+
+interface IOptions {
+  injectServerHost: string;
+}
+
+const Inject = (ctx: ILowCodePluginContext, options: IOptions) => {
+  console.log('options?.injectServerHost', options?.injectServerHost)
+  if (options?.injectServerHost) {
+    injectServerHost = options.injectServerHost;
+  }
   // inject 已有的设计器插件
   if (needInject) {
     // 覆盖后续的插件注册逻辑，所有只有本插件后面注册的插件才可以支持 inject 逻辑
@@ -87,6 +100,19 @@ const Inject = (ctx: ILowCodePluginContext) => {
 Inject.pluginName = 'LowcodePluginInjectAlt';
 
 export default Inject;
+Inject.meta = {
+  dependencies: [],
+  preferenceDeclaration: {
+    title: '注入资源的主机地址',
+    properties: [
+      {
+        key: 'injectServerHost',
+        type: 'string',
+        description: '注入资源的主机地址',
+      },
+    ],
+  },
+};
 
 export {
   injectAssets,

--- a/packages/lowcode-plugin-inject/src/index.tsx
+++ b/packages/lowcode-plugin-inject/src/index.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
 import { ILowCodePluginContext, plugins, setters } from '@alilc/lowcode-engine';
-import { getInjectedResource, injectAssets, needInject, injectComponents, filterPackages } from './utils';
+import { getInjectedResource, injectAssets, needInject, injectComponents, filterPackages, setInjectServerHost } from './utils';
 import { Notification } from '@alifd/next';
 
 
 let injectedPluginConfigMap = null;
 let injectedPlugins = [];
-let injectServerHost = '127.0.0.1';
 
 export async function getInjectedPlugin(name: string, ctx: ILowCodePluginContext) {
   if (!injectedPluginConfigMap) {
@@ -22,18 +21,13 @@ export async function getInjectedPlugin(name: string, ctx: ILowCodePluginContext
   return injectedPluginConfigMap[name];
 }
 
-export function getInjectServerHost() {
-  return injectServerHost;
-}
-
 interface IOptions {
   injectServerHost: string;
 }
 
 const Inject = (ctx: ILowCodePluginContext, options: IOptions) => {
-  console.log('options?.injectServerHost', options?.injectServerHost)
   if (options?.injectServerHost) {
-    injectServerHost = options.injectServerHost;
+    setInjectServerHost(options.injectServerHost);
   }
   // inject 已有的设计器插件
   if (needInject) {

--- a/packages/lowcode-plugin-inject/src/utils.tsx
+++ b/packages/lowcode-plugin-inject/src/utils.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { pascal } from 'case';
 import { Notification } from '@alifd/next';
 import { buildComponents } from '@alilc/lowcode-utils';
-import { getInjectServerHost } from '.';
 
 const typeMap = {
   vc: ['prototype', 'view'],
@@ -31,6 +30,8 @@ window[jsonpFlag] = function addComponents(component) {
   window[arrayFlag].push(component);
 };
 
+let injectServerHost = '127.0.0.1';
+
 const searchParams = new URLSearchParams(window.location.search);
 // 是否需要开启 inject 逻辑
 
@@ -41,6 +42,12 @@ export const needInject = searchParams.get('__injectFrom') // 历史兼容
 
 
 let urlCache = null;
+
+export function setInjectServerHost(finalInjectServerHost) {
+  injectServerHost = finalInjectServerHost;
+  console.log('inject server host', injectServerHost);
+}
+
 // 获取 inject 资源的 url，格式：['url1', 'url2']
 function getInjectUrls(resourceType, type = 'url'): Promise<any> {
   const filter = (_urls) => {
@@ -67,7 +74,7 @@ function getInjectUrls(resourceType, type = 'url'): Promise<any> {
 
       const { type, injects } = window.injectConfig || {};
       if (type === 'auto' || urlParams[injectTypeFlag] === 'auto' || urlParams[debugFlag] !== undefined) {
-        fetchJsonp(`http://${getInjectServerHost()}:8899/apis/injectInfo`).then(res => res.json()).then((data) => {
+        fetchJsonp(`http://${injectServerHost}:8899/apis/injectInfo`).then(res => res.json()).then((data) => {
           urls = envFilter(data.content);
           urlCache = urls;
           resolve(filter(urlCache));

--- a/packages/lowcode-plugin-inject/src/utils.tsx
+++ b/packages/lowcode-plugin-inject/src/utils.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { pascal } from 'case';
 import { Notification } from '@alifd/next';
 import { buildComponents } from '@alilc/lowcode-utils';
+import { getInjectServerHost } from '.';
 
 const typeMap = {
   vc: ['prototype', 'view'],
@@ -19,7 +20,6 @@ const queryFlag = '__injectFrom'; // 不推荐
 const injectTypeFlag = '__injectType'; // 不推荐
 const injectEnvFlag = '__injectEnv'; // 不推荐
 const debugFlag = 'debug'; // 推荐
-const injectAPIUrl = 'http://127.0.0.1:8899/apis/injectInfo';
 const arrayFlag = '__components';
 const jsonpFlag = '__injectComponent';
 const prototypeKeyFlag = '__prototype';
@@ -67,7 +67,7 @@ function getInjectUrls(resourceType, type = 'url'): Promise<any> {
 
       const { type, injects } = window.injectConfig || {};
       if (type === 'auto' || urlParams[injectTypeFlag] === 'auto' || urlParams[debugFlag] !== undefined) {
-        fetchJsonp(injectAPIUrl).then(res => res.json()).then((data) => {
+        fetchJsonp(`http://${getInjectServerHost()}:8899/apis/injectInfo`).then(res => res.json()).then((data) => {
           urls = envFilter(data.content);
           urlCache = urls;
           resolve(filter(urlCache));


### PR DESCRIPTION
背景：在本机开发好物料，注入到demo项目没有问题，同局域网下的其他主机访问则不能注入物料，因此修改部分逻辑支持该场景，修改逻辑如下，lowcode-plugin-inject 支持通过请求参数控制获取注入资源的主机地址，注入服务监听端口修改为0.0.0.0，返回的注入资源路径以devServer 当前运行的主机Ip为准