### PR TITLE
响应头增加Access-Control-Allow-Private-Network

### DIFF
--- a/packages/build-plugin-alt/src/inject/apis.ts
+++ b/packages/build-plugin-alt/src/inject/apis.ts
@@ -66,6 +66,7 @@ const init = async () => {
       'Content-Type, Content-Length, Authorization, Accept, X-Requested-With , sessionToken',
     );
     ctx.res.setHeader('Access-Control-Allow-Methods', 'PUT, POST, GET, DELETE, OPTIONS');
+    ctx.res.setHeader('Access-Control-Allow-Private-Network', 'true');
     ctx.type = 'text/javascript';
     const callbackName = ctx.query.callback || 'callback';
     const filePath = getFilePath();


### PR DESCRIPTION
为了支持这种场景调试

http://mylowcode-engine.com 请求 http://127.0.0.1:8899 

非安全站点跨域请求本地资源,被浏览器阻止


参考: https://web.dev/cors-rfc1918-feedback/