### PR TITLE
fix: windows import path

### DIFF
--- a/packages/build-plugin-lowcode/src/index.js
+++ b/packages/build-plugin-lowcode/src/index.js
@@ -63,7 +63,7 @@ const defaultScssEntryPaths = [
 
 function getEntry(rootDir, entryPath) {
   if (entryPath && fse.existsSync(path.resolve(rootDir, entryPath))) {
-    return path.resolve(rootDir, entryPath);
+    return path.resolve(rootDir, entryPath).replace(/\\/g, '\\\\');
   }
   for (let i = 0; i < defaultEntryPaths.length; i++) {
     const p = path.resolve(rootDir, defaultEntryPaths[i]);
@@ -950,7 +950,8 @@ async function bundleRenderView(options, pluginOptions, platform, execCompile) {
       return `const ${component} = getRealComponent(${component}Data, '${component}');\nexport { ${component} };`;
     })
     .join('\n');
-  componentViewsExportStr += `\nexport { default } from '${getEntry(rootDir, entryPath)}';`;
+  const exportPath = `\nexport { default } from '${getEntry(rootDir, entryPath)}';`;
+  componentViewsExportStr += exportPath.includes('\\\\') ? exportPath : exportPath.replace(/\\/g, '\\\\');
   componentViewsImportStr = _componentViews
     .map((component) => {
       const componentNameFolder = camel2KebabComponentName(component);


### PR DESCRIPTION
## 解决windows下，.tpm/views.js中的文件路径问题（少一条反斜杠），导致文件路径错误。

文件路径错误，windows无法lowcode:dev/lowcode:build.

已修复，mac也验证过了，没有影响。

再次感谢lowcode，是个伟大的产品，很好用。
