### PR TITLE
fix(build-plugin-lowcode): fix component dependencies order

### DIFF
--- a/packages/build-plugin-lowcode/src/templates/index.jsx
+++ b/packages/build-plugin-lowcode/src/templates/index.jsx
@@ -172,7 +172,7 @@ init(() => {
 
       // 覆盖basePackages中相同library
       const packagesMap = new Map();
-      assets.packages = [...assets.packages, ...basePackages].filter((pkg) => !packagesMap.has(pkg.library) && packagesMap.set(pkg.library, 1))
+      assets.packages = [...basePackages, ...assets.packages].filter((pkg) => !packagesMap.has(pkg.library) && packagesMap.set(pkg.library, 1))
 
       assets.packages = assets.packages.map(item => {
         if (item.editUrls && item.editUrls.length) {


### PR DESCRIPTION
#27 本次PR中更改了basePackages 和 assets.package 顺序，导致组件异常报错

![image](https://user-images.githubusercontent.com/14230248/231933548-8f14e0a5-6520-4adb-88f4-ba26e8422bb1.png)

复现步骤：
1. `npm init @alilc/element your-material-name`
2. 创建react-组件库
3.  npm install
4. npm run lowcode:dev
5. 拖动组件至页面，发现报错