### PR TITLE
fix: extraAssets覆盖basePackages中相同library并保持basePackages在前的顺序

### DIFF
--- a/packages/build-plugin-lowcode/package.json
+++ b/packages/build-plugin-lowcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alifd/build-plugin-lowcode",
-  "version": "0.3.12",
+  "version": "0.3.10",
   "description": "build plugin for component-to-lowcode",
   "main": "src/index.js",
   "keywords": [

--- a/packages/build-plugin-lowcode/package.json
+++ b/packages/build-plugin-lowcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alifd/build-plugin-lowcode",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "build plugin for component-to-lowcode",
   "main": "src/index.js",
   "keywords": [

--- a/packages/build-plugin-lowcode/package.json
+++ b/packages/build-plugin-lowcode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alifd/build-plugin-lowcode",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "description": "build plugin for component-to-lowcode",
   "main": "src/index.js",
   "keywords": [

--- a/packages/build-plugin-lowcode/src/templates/index.jsx
+++ b/packages/build-plugin-lowcode/src/templates/index.jsx
@@ -172,7 +172,7 @@ init(() => {
 
       // 覆盖basePackages中相同library
       const packagesMap = new Map();
-      assets.packages = [...assets.packages, ...basePackages].filter((pkg) => !packagesMap.has(pkg.library) && packagesMap.set(pkg.library, 1))
+      assets.packages = [...basePackages, ...assets.packages].filter((pkg) => !packagesMap.has(pkg.library) && packagesMap.set(pkg.library, 1))
 
       assets.packages = assets.packages.map(item => {
         if (item.editUrls && item.editUrls.length) {

--- a/packages/build-plugin-lowcode/src/templates/index.jsx
+++ b/packages/build-plugin-lowcode/src/templates/index.jsx
@@ -172,7 +172,8 @@ init(() => {
 
       // 覆盖basePackages中相同library
       const packagesMap = new Map();
-      assets.packages = [...basePackages, ...assets.packages].filter((pkg) => !packagesMap.has(pkg.library) && packagesMap.set(pkg.library, 1))
+      const tmpPackages = [...assets.packages, ...basePackages].filter((pkg) => !packagesMap.has(pkg.library) && packagesMap.set(pkg.library, pkg));
+      assets.packages = [...new Set([...basePackages, ...assets.packages].map((pkg) => pkg.library))].map((library) => packagesMap.get(library))
 
       assets.packages = assets.packages.map(item => {
         if (item.editUrls && item.editUrls.length) {

--- a/packages/build-plugin-lowcode/src/templates/index.jsx
+++ b/packages/build-plugin-lowcode/src/templates/index.jsx
@@ -173,7 +173,7 @@ init(() => {
       // 覆盖basePackages中相同library
       const packagesMap = new Map();
       const tmpPackages = [...assets.packages, ...basePackages].filter((pkg) => !packagesMap.has(pkg.library) && packagesMap.set(pkg.library, pkg));
-      assets.packages = [...new Set([...basePackages, ...assets.packages].map((pkg) => pkg.library))].map((library) => packagesMap.get(library))
+      assets.packages = [...new Set([...basePackages, ...assets.packages].map((pkg) => pkg.library))].map((library) => packagesMap.get(library));
 
       assets.packages = assets.packages.map(item => {
         if (item.editUrls && item.editUrls.length) {

--- a/packages/build-plugin-lowcode/src/templates/index.jsx
+++ b/packages/build-plugin-lowcode/src/templates/index.jsx
@@ -170,7 +170,14 @@ init(() => {
         builtinAssets && await handleExtraAssets(assets, builtinAssets);
       }
 
-      assets.packages = basePackages.concat(assets.packages);
+      // 覆盖basePackages中相同library
+      const filterBasePackages = basePackages.filter(bp => 
+        !Array.from(assets.packages).some(ap => 
+          ap.library === bp.library
+        )
+      )
+      assets.packages = assets.packages.concat(filterBasePackages);
+
       assets.packages = assets.packages.map(item => {
         if (item.editUrls && item.editUrls.length) {
           item.renderUrls = item.urls;

--- a/packages/build-plugin-lowcode/src/templates/index.jsx
+++ b/packages/build-plugin-lowcode/src/templates/index.jsx
@@ -171,12 +171,8 @@ init(() => {
       }
 
       // 覆盖basePackages中相同library
-      const filterBasePackages = basePackages.filter(bp => 
-        !Array.from(assets.packages).some(ap => 
-          ap.library === bp.library
-        )
-      )
-      assets.packages = assets.packages.concat(filterBasePackages);
+      const packagesMap = new Map();
+      assets.packages = [...assets.packages, ...basePackages].filter((pkg) => !packagesMap.has(pkg.library) && packagesMap.set(pkg.library, 1))
 
       assets.packages = assets.packages.map(item => {
         if (item.editUrls && item.editUrls.length) {


### PR DESCRIPTION
覆盖basePackages中相同library并保持原先顺序