### PR TITLE
fix(build-plugin-lowcode): win平台，在lowcode目录下定义view.ts后获取到的路径不对

### DIFF
--- a/packages/build-plugin-lowcode/src/index.js
+++ b/packages/build-plugin-lowcode/src/index.js
@@ -962,7 +962,7 @@ async function bundleRenderView(options, pluginOptions, platform, execCompile) {
   componentViewsImportStr = _componentViews
     .map((component) => {
       const componentNameFolder = camel2KebabComponentName(component);
-      const viewJsPath = path.resolve(
+      const viewJsPath = getEntry(
         rootDir,
         `src/${platform}/components/${componentNameFolder}/view`,
       );


### PR DESCRIPTION
修改前 .tmp -> view.js `import * as FilterData from 'F:\component\pakcages\material\lowcode\filter\view'`
修改后 修改前 .tmp -> view.js `import * as FilterData from 'F:\\component\\pakcages\\material\\lowcode\\filter\\view'`