### PR TITLE
fix: 修复注入模式监听异常导致报错的问题

### DIFF
--- a/packages/build-plugin-alt/src/inject/apis.ts
+++ b/packages/build-plugin-alt/src/inject/apis.ts
@@ -26,8 +26,8 @@ function makeJsonpStr(cbName, data) {
   return `;${cbName}(${JSON.stringify(data)})`
 }
 
-async function portIsOccupied(_port) {
-  const server = net.createServer().listen(_port);
+async function portIsOccupied(_port, _host) {
+  const server = net.createServer().listen(_port, _host);
   // eslint-disable-next-line no-shadow
   return new Promise((resolve) => {
     server.on('listening', () => {
@@ -47,9 +47,9 @@ const HOST = '0.0.0.0';
 
 const init = async () => {
 
-  if (await portIsOccupied(PORT)) {
+  if (await portIsOccupied(PORT, HOST)) {
     const timer = setInterval(async () => {
-      const isOccupied = await portIsOccupied(PORT);
+      const isOccupied = await portIsOccupied(PORT, HOST);
       if (!isOccupied) {
         logger.info('Original inject server is down, start another')
         clearInterval(timer);


### PR DESCRIPTION
修复注入模式监听异常导致报错的问题：因为 listen(_port) 没有加 host，第二次启动 inject 服务时，依然能够成功执行server.on('listening')，导致判断当前已有服务的逻辑失效，然后在执行 app.listen(PORT, HOST)时报错。

报错信息为：Error: listen EADDRINUSE: address already in use 0.0.0.0:8899

复现流程：
1、脚手架初始化两个插件：npm init @alilc/element plugin-test-1 ,   npm init @alilc/element plugin-test-2
2、安装依赖并启动：npm i  ,  npm run dev
3、第二个插件启动报错

node版本：v16.13.1 和 14.21.3 都试过