### PR TITLE
fix: react template add devDependencies for npm run lowcode:dev

### DIFF
--- a/packages/template-material/react-multiple-component-template/projectTemplate/package.json
+++ b/packages/template-material/react-multiple-component-template/projectTemplate/package.json
@@ -68,7 +68,11 @@
     "@umijs/plugin-sass": "^1.1.1",
     "dumi": "^1.1.49",
     "dumi-theme-default": "^1.1.24",
-    "f2elint": "^1.2.0"
+    "f2elint": "^1.2.0",
+    "@alilc/lowcode-react-renderer": "^1.0.1",
+    "@alilc/lowcode-utils": "^1.0.1",
+    "style-loader": "^2.0.0",
+    "lodash": "^4.17.21"
   },
   "dependencies": {
     "moment": "^2.29.4",

--- a/packages/template-material/react-single-component-template/projectTemplate/package.json
+++ b/packages/template-material/react-single-component-template/projectTemplate/package.json
@@ -56,7 +56,11 @@
     "build-plugin-component": "^1.0.0",
     "template-component-demo": "^2.0.3",
     "build-plugin-moment-locales": "^0.1.0",
-    "f2elint": "^1.2.0"
+    "f2elint": "^1.2.0",
+    "@alilc/lowcode-react-renderer": "^1.0.1",
+    "@alilc/lowcode-utils": "^1.0.1",
+    "style-loader": "^2.0.0",
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "moment": "latest",


### PR DESCRIPTION
使用 `npm init @alilc/element your-material-name` 初始化出来用来开发组件物料的工程。运行npm run lowcode:dev会报错。

因为build.lowcode.js中使用插件：@alifd/build-plugin-lowcode，其templates中的preview.jsx和index.jsx使用了PR的内容。因为在运行lowcode:dev的时候，会拷贝到当前工程的.tmp目录下，但是初始化出来的项目中，并没有这些依赖，导致运行报错了。